### PR TITLE
fix: widen ovos-plugin-manager to <3.0.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,1 @@
-ovos-plugin-manager>=2.1.0,<2.2.0
+ovos-plugin-manager>=2.1.0,<3.0.0


### PR DESCRIPTION
Surfaced by the ovos-releases full-set alpha co-install check: the <2.2.0 cap is the only thing keeping this plugin out of the resolvable alpha set.

## How to test
`uv pip install --dry-run --pre ovos-media-plugin-mplayer ovos-plugin-manager>=2.4.0a2` resolves with this change; conflicts without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded dependency version support to allow compatibility with newer versions of the plugin manager, enabling access to the latest features, improvements, and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->