### PR TITLE
feat: dual-target — add legacy ovos-audio service entry point

### DIFF
--- a/ovos_plugin_mplayer/__init__.py
+++ b/ovos_plugin_mplayer/__init__.py
@@ -8,6 +8,16 @@ from ovos_plugin_mplayer.mplayerlib import MplayerCtrl
 class MplayerBaseService(MediaBackend):
     def __init__(self, config, bus=None, video=False):
         super().__init__(config, bus)
+        self._init_mplayer(config, bus, video=video)
+
+    def _init_mplayer(self, config, bus=None, video=False):
+        """Set up the mplayer engine + event handlers.
+
+        Factored out of ``__init__`` so it can be shared by both the new
+        ``MediaBackend`` (ovos-media) backends and the legacy ``AudioBackend``
+        (ovos-audio) adapter, which have different base-class constructors but
+        drive the same mplayer engine underneath.
+        """
         self.config = config
         self.bus = bus
 

--- a/ovos_plugin_mplayer/audio.py
+++ b/ovos_plugin_mplayer/audio.py
@@ -1,0 +1,42 @@
+"""Legacy ``ovos-audio`` (mycroft.plugin.audioservice) adapter.
+
+The same mplayer engine as the new ovos-media :class:`MplayerOCPAudioService`,
+exposed under the legacy audio-service contract so this plugin works on both
+stacks:
+
+* new ``ovos-media`` — ``opm.media.audio`` → :class:`~ovos_plugin_mplayer.MplayerOCPAudioService`
+* legacy ``ovos-audio`` — ``mycroft.plugin.audioservice`` → :class:`MplayerAudioService`
+  (discovered via :func:`load_service`)
+"""
+from ovos_plugin_manager.templates.audio import AudioBackend
+from ovos_utils.log import LOG
+
+from ovos_plugin_mplayer import MplayerBaseService
+
+
+class MplayerAudioService(MplayerBaseService, AudioBackend):
+    """mplayer backend for the legacy ovos-audio service.
+
+    Reuses every playback method (``play``/``stop``/``pause``/``resume``/
+    seek/volume/track-info) from :class:`MplayerBaseService`; only the
+    constructor differs because the legacy ``AudioBackend`` takes a ``name``.
+
+    ``MplayerBaseService`` is listed first so its concrete methods satisfy the
+    abstract playback methods declared on ``AudioBackend`` (MRO order matters).
+    """
+
+    def __init__(self, config, bus=None, name='mplayer'):
+        AudioBackend.__init__(self, config, bus, name)
+        # set up the mplayer engine without the new MediaBackend constructor
+        self._init_mplayer(config, bus, video=False)
+
+
+def load_service(base_config, bus):
+    backends = base_config.get('backends', {})
+    services = [(b, backends[b]) for b in backends
+                if backends[b].get('type') in ['mplayer', 'ovos_mplayer'] and
+                backends[b].get('active', True)]
+    instances = [MplayerAudioService(s[1], bus, s[0]) for s in services]
+    if len(instances) == 0:
+        LOG.warning("No mplayer backends have been configured")
+    return instances

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ ovos-media-audio-plugin-mplayer = "ovos_plugin_mplayer.MplayerOCPAudioService"
 [project.entry-points."opm.media.video"]
 ovos-media-video-plugin-mplayer = "ovos_plugin_mplayer:MplayerOCPVideoService"
 
+# legacy ovos-audio service backend (so the plugin works on both stacks)
+[project.entry-points."mycroft.plugin.audioservice"]
+ovos_mplayer = "ovos_plugin_mplayer.audio"
+
 [tool.setuptools.dynamic]
 version = { attr = "ovos_plugin_mplayer.version.__version__" }
 

--- a/test/unittests/test_backends.py
+++ b/test/unittests/test_backends.py
@@ -1,0 +1,89 @@
+"""Unit tests for the mplayer backends.
+
+The mplayer control lib is not available in CI, so
+``ovos_plugin_mplayer.mplayerlib`` is mocked in ``sys.modules`` before
+importing the plugin. The tests assert wiring/contract, not real playback:
+both the new ovos-media backends and the legacy ovos-audio adapter build,
+expose the right base classes, and the supported URIs + entry points are
+declared correctly.
+"""
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+
+# --- mock the mplayer control lib so the plugin imports without mplayer -------
+# ``ovos_plugin_mplayer.mplayerlib`` is a submodule of the package, so stub the
+# whole module with a MagicMock ``MplayerCtrl`` attribute before import.
+_mplayerlib = types.ModuleType("ovos_plugin_mplayer.mplayerlib")
+_mplayerlib.MplayerCtrl = MagicMock()
+sys.modules["ovos_plugin_mplayer.mplayerlib"] = _mplayerlib
+
+from ovos_plugin_manager.templates.media import (
+    AudioPlayerBackend, VideoPlayerBackend)
+from ovos_plugin_manager.templates.audio import AudioBackend
+
+from ovos_plugin_mplayer import (
+    MplayerBaseService, MplayerOCPAudioService, MplayerOCPVideoService)
+from ovos_plugin_mplayer.audio import MplayerAudioService, load_service
+
+
+class TestNewBackends(unittest.TestCase):
+    def test_audio_backend_is_audioplayerbackend(self):
+        svc = MplayerOCPAudioService({}, bus=MagicMock())
+        self.assertIsInstance(svc, AudioPlayerBackend)
+        self.assertIsInstance(svc, MplayerBaseService)
+
+    def test_video_backend_is_videoplayerbackend(self):
+        svc = MplayerOCPVideoService({}, bus=MagicMock())
+        self.assertIsInstance(svc, VideoPlayerBackend)
+
+    def test_supported_uris(self):
+        svc = MplayerOCPAudioService({}, bus=MagicMock())
+        self.assertEqual(svc.supported_uris(), ['file', 'http', 'https'])
+
+
+class TestLegacyAdapter(unittest.TestCase):
+    def test_legacy_is_audiobackend(self):
+        svc = MplayerAudioService({}, bus=MagicMock(), name='mplayer')
+        self.assertIsInstance(svc, AudioBackend)
+        # reuses the shared mplayer engine/methods
+        self.assertIsInstance(svc, MplayerBaseService)
+        self.assertTrue(hasattr(svc, "play"))
+        self.assertTrue(hasattr(svc, "lower_volume"))
+
+    def test_supported_uris(self):
+        svc = MplayerAudioService({}, bus=MagicMock(), name='mplayer')
+        self.assertEqual(svc.supported_uris(), ['file', 'http', 'https'])
+
+    def test_load_service_builds_active_mplayer_backends(self):
+        cfg = {"backends": {
+            "a": {"type": "mplayer", "active": True},
+            "b": {"type": "mplayer", "active": False},
+            "c": {"type": "mpv", "active": True},
+        }}
+        services = load_service(cfg, bus=MagicMock())
+        self.assertEqual(len(services), 1)
+        self.assertIsInstance(services[0], MplayerAudioService)
+
+    def test_load_service_empty(self):
+        self.assertEqual(load_service({"backends": {}}, bus=MagicMock()), [])
+
+
+class TestEntryPoints(unittest.TestCase):
+    """Both the new and legacy entry-point groups must be declared."""
+
+    def test_setup_declares_new_and_legacy_groups(self):
+        import os
+        here = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        with open(os.path.join(here, "pyproject.toml")) as f:
+            setup_src = f.read()
+        self.assertIn("opm.media.audio", setup_src)
+        self.assertIn("opm.media.video", setup_src)
+        self.assertIn("mycroft.plugin.audioservice", setup_src)
+        self.assertIn("ovos_plugin_mplayer.audio", setup_src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Makes this plugin work on **both** playback stacks by exposing the same mplayer engine under the new and legacy entry-point groups.

## Entry points
- new `ovos-media`:
  - `opm.media.audio` → `MplayerOCPAudioService`
  - `opm.media.video` → `MplayerOCPVideoService`
- legacy `ovos-audio`:
  - `mycroft.plugin.audioservice` → `ovos_mplayer=ovos_plugin_mplayer.audio` (discovered via `load_service`)

## Shared-engine refactor
`MplayerBaseService.__init__` now delegates engine setup to a new `_init_mplayer()` method. This lets both base classes drive the same engine despite different constructors:
- the new `MediaBackend` backends call it via `__init__`
- the new legacy `MplayerAudioService(MplayerBaseService, AudioBackend)` calls `AudioBackend.__init__(...)` (for the `name` arg) then `_init_mplayer(...)`. `MplayerBaseService` is listed first in the MRO so its concrete playback methods satisfy `AudioBackend`'s abstract methods.

## Tests
Adds `test/unittests/test_backends.py` (mplayer control lib mocked in `sys.modules`) covering the new + legacy backends, `supported_uris`, `load_service` filtering, and the declared entry points. Removes the placeholder test. 8 passing.

Mirrors the just-merged pattern in `ovos-media-plugin-vlc` (PR #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)