### PR TITLE
test: end-to-end test via ovoscope OCPPlayerHarness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest",
+    # end-to-end harness: drives the real backend through a real OCPMediaPlayer.
+    # [media] (the OCPPlayerHarness) lands in ovoscope 0.20.x; floor-pin so pip
+    # resolves it without --pre once published.
+    "ovoscope[media]>=0.20.0a1",
 ]
 
 [project.urls]

--- a/test/test_e2e.py
+++ b/test/test_e2e.py
@@ -1,0 +1,63 @@
+"""End-to-end tests: drive the real mplayer OCP backend through a real
+``OCPMediaPlayer`` on a FakeBus via ovoscope's media harness.
+
+The mplayer *engine* (the ``MplayerCtrl`` slave-process controller) is mocked so
+no real player/binary is spawned, but everything else is real: the OCP player
+routes the play/pause/stop/seek requests to ``MplayerOCPAudioService`` exactly as
+ovos-media would at runtime.
+
+Requires ``ovoscope[media]`` (pulls ovos-media).
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+try:
+    from ovoscope import OCPPlayerHarness
+    from ovos_utils.ocp import MediaEntry, PlaybackType, PlayerState
+    HAVE_HARNESS = True
+except Exception:
+    HAVE_HARNESS = False
+
+import ovos_plugin_mplayer
+from ovos_plugin_mplayer import MplayerOCPAudioService
+
+URI = "http://example.com/song.mp3"
+
+
+def _factory(bus):
+    """Build the real mplayer audio backend for injection into the OCP player."""
+    return MplayerOCPAudioService({}, bus)
+
+
+@unittest.skipUnless(HAVE_HARNESS, "ovoscope[media] not installed")
+class TestMplayerEndToEnd(unittest.TestCase):
+    def test_play_pause_resume_stop_through_ocp(self):
+        with patch.object(ovos_plugin_mplayer, "MplayerCtrl", MagicMock()):
+            with OCPPlayerHarness(backend_factory=_factory) as h:
+                entry = MediaEntry(uri=URI, playback=PlaybackType.AUDIO)
+
+                h.play(entry)
+                h.assert_player_state(PlayerState.PLAYING)
+                h.assert_now_playing_uri(URI)
+                # the real backend actually started its (mocked) mplayer engine
+                self.assertIsNotNone(h.backend.mpc)
+
+                h.pause()
+                h.assert_player_state(PlayerState.PAUSED)
+
+                h.resume()
+                h.assert_player_state(PlayerState.PLAYING)
+
+                h.stop()
+                h.assert_player_state(PlayerState.STOPPED)
+
+    def test_backend_is_the_real_mplayer_plugin(self):
+        with patch.object(ovos_plugin_mplayer, "MplayerCtrl", MagicMock()):
+            with OCPPlayerHarness(backend_factory=_factory) as h:
+                self.assertIsInstance(h.backend, MplayerOCPAudioService)
+                self.assertEqual(h.backend.supported_uris(),
+                                 ["file", "http", "https"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_backends.py
+++ b/test/unittests/test_backends.py
@@ -24,6 +24,14 @@ from ovos_plugin_manager.templates.media import (
     AudioPlayerBackend, VideoPlayerBackend)
 from ovos_plugin_manager.templates.audio import AudioBackend
 
+import ovos_plugin_mplayer
+# Force-mock the MplayerCtrl bound in the package namespace. The sys.modules stub
+# above only wins if this module is imported first; a sibling test (e.g. test_e2e)
+# that imports the package earlier would already have bound the real MplayerCtrl
+# (which spawns the `mplayer` binary at construction). Patching the package symbol
+# makes the contract tests order-independent.
+ovos_plugin_mplayer.MplayerCtrl = MagicMock()
+
 from ovos_plugin_mplayer import (
     MplayerBaseService, MplayerOCPAudioService, MplayerOCPVideoService)
 from ovos_plugin_mplayer.audio import MplayerAudioService, load_service


### PR DESCRIPTION
Drive the real `MplayerOCPAudioService` through a real ovos-media `OCPMediaPlayer` on a FakeBus via ovoscope's `OCPPlayerHarness`, exercising the full play/pause/resume/stop flow + now_playing routing. The `MplayerCtrl` engine is mocked so no real player/binary is spawned.

Declares the `ovoscope[media]>=0.20.0a1` test extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)